### PR TITLE
fix: iOS didRegisterForRemoteNotificationsWithDeviceToken not called

### DIFF
--- a/ios/Classes/SonaPlugin.m
+++ b/ios/Classes/SonaPlugin.m
@@ -15,6 +15,7 @@
     SonaPlugin *instance = [SonaPlugin sonaPlugin];
     [instance setMethodChannel:channel];
     [registrar addMethodCallDelegate:instance channel:channel];
+	[registrar addApplicationDelegate:instance];
 }
 
 FlutterMethodChannel *sonMethodChannel;


### PR DESCRIPTION
deviceToken can be registered now. Tested on iOS 12